### PR TITLE
chore(api-client): migrate to 5.0.2-next.10 via legacy client

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@fastify/rate-limit": "8.1.1",
     "@fastify/sensible": "5.6.0",
     "@innei/next-async": "0.4.0",
-    "@mx-space/api-client": "2.4.0",
+    "@mx-space/api-client": "5.0.2-next.10",
     "@mx-space/webhook": "0.8.3",
     "@tanstack/query-core": "4.41.0",
     "axios": "1.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 0.4.0
         version: 0.4.0
       '@mx-space/api-client':
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: 5.0.2-next.10
+        version: 5.0.2-next.10
       '@mx-space/webhook':
         specifier: 0.8.3
         version: 0.8.3
@@ -560,8 +560,8 @@ packages:
     resolution: {integrity: sha512-Xs/4RZltsAL7pkvaNStUQt7netTkyxrS0K+RILcVr3TRMS/ToOg4I6uNfhB9SlGsnWBym4U+EaXq0f0cEMNkHA==}
     engines: {node: '>=8'}
 
-  '@mx-space/api-client@2.4.0':
-    resolution: {integrity: sha512-72TlkdX+NbZCRu0rFZ84QCFu5CRBW0yrjL5QgbCqOo9m2gnm0j66ECvkaPBT8mgcOZgAkMrncHeDfZWuajmdeQ==}
+  '@mx-space/api-client@5.0.2-next.10':
+    resolution: {integrity: sha512-KcOaDuwCaWBh9Qbvs/nIciMzF2TrbEW7BP+LaOiRTsLII+fWUgvmfvIZn+0mgHCiCBR4OEPOeWYDlybxIoocqw==}
     engines: {node: '>=22'}
 
   '@mx-space/webhook@0.8.3':
@@ -3273,7 +3273,9 @@ snapshots:
 
   '@lukeed/ms@2.0.1': {}
 
-  '@mx-space/api-client@2.4.0': {}
+  '@mx-space/api-client@5.0.2-next.10':
+    dependencies:
+      rebuild: 0.1.2
 
   '@mx-space/webhook@0.8.3':
     dependencies:

--- a/src/modules/mx-space/api-client.ts
+++ b/src/modules/mx-space/api-client.ts
@@ -2,8 +2,9 @@ import { appConfig } from "~/app.config";
 import chalk from "chalk";
 import type { AxiosResponse, InternalAxiosRequestConfig } from "axios";
 
-import { allControllers, createClient } from "@mx-space/api-client";
+import { allControllers } from "@mx-space/api-client";
 import { axiosAdaptor } from "@mx-space/api-client/dist/adaptors/axios";
+import { createLegacyApiClient } from "@mx-space/api-client/legacy";
 
 import { userAgent } from "~/constants";
 import { createNamespaceLogger } from "~/lib/logger";
@@ -52,7 +53,7 @@ axiosAdaptor.default.interceptors.response.use(
     return error;
   },
 );
-export const apiClient = createClient(axiosAdaptor)(
+export const apiClient = createLegacyApiClient(axiosAdaptor)(
   appConfig.mxSpace?.apiEndpoint,
   {
     controllers: allControllers,

--- a/src/modules/mx-space/event-handlers/comment-create.ts
+++ b/src/modules/mx-space/event-handlers/comment-create.ts
@@ -58,9 +58,7 @@ const buildCommentMessage = (
   const title = refModel.title;
 
   if (isMaster && !parentCommentId) {
-    const createdAt =
-      (refModel as { createdAt?: string }).createdAt ?? refModel.created;
-    const ago = relativeTimeFromNow(createdAt);
+    const ago = relativeTimeFromNow(refModel.createdAt);
     return richify`${author} 在「${title}」发表之后的 ${ago}又说：${md(text)}`;
   }
 

--- a/src/modules/mx-space/index.ts
+++ b/src/modules/mx-space/index.ts
@@ -199,7 +199,7 @@ async function bindCommands(tgBot: Telegraf) {
         const text = data.data
           .map(
             (note) =>
-              `${relativeTimeFromNow(note.created)}前\n[${escapeMarkdown(
+              `${relativeTimeFromNow(note.createdAt)}前\n[${escapeMarkdown(
                 note.title,
               )}](${webUrl}/notes/${note.nid})`,
           )
@@ -222,7 +222,7 @@ async function bindCommands(tgBot: Telegraf) {
         const text = data.data
           .map(
             (post) =>
-              `${relativeTimeFromNow(post.created)}前\n[${escapeMarkdown(
+              `${relativeTimeFromNow(post.createdAt)}前\n[${escapeMarkdown(
                 post.title,
               )}](${webUrl}/posts/${post.category.slug}/${post.slug})`,
           )


### PR DESCRIPTION
## Summary

- Bump `@mx-space/api-client` from V1 `2.4.0` to V3 `5.0.2-next.10`
- Swap `createClient` → `createLegacyApiClient` so the V1 envelope shape (`data.data[...]`) keeps working with the V3 wire format
- Rename `note.created`/`post.created` to V3 `createdAt`
- Drop the temporary `createdAt` fallback in `comment-create.ts` now that V3 is the single source

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm build` succeeds
- [ ] Smoke: `mx_get_posts`, `mx_get_notes`, `mx_get_detail`, `mx_stat` commands return data
- [ ] Smoke: webhook comment/link-apply/activity-like deliveries

Depends on `@mx-space/api-client@5.0.2-next.10` (published to npm).